### PR TITLE
fix: support shared components

### DIFF
--- a/src/main/@types/copy-package-generator-args.type.ts
+++ b/src/main/@types/copy-package-generator-args.type.ts
@@ -5,5 +5,5 @@ export type CopyPackageGeneratorArgs = {
   npmPackage: Pick<NpmPackage, 'name'>;
   generator: string;
   sourceTemplateDir: string;
-  targetTemplateDir: string;
+  hygenCookDir: string;
 } & Pick<CookArgs, 'shouldOverwriteTemplates'>;

--- a/src/main/constants.ts
+++ b/src/main/constants.ts
@@ -1,0 +1,1 @@
+export const HYGEN_COOK_DIR = '_hygencook';

--- a/src/main/exec-instructions.ts
+++ b/src/main/exec-instructions.ts
@@ -1,5 +1,6 @@
-import { resolve } from 'path';
+import { resolve, join } from 'path';
 import { Arg, Instruction } from './@types';
+import { HYGEN_COOK_DIR } from './constants';
 import { runHygen } from './hygen/run-hygen';
 
 /**
@@ -20,6 +21,16 @@ function prepareArgs(args: Arg[]): string[] {
     ],
     [] as string[],
   );
+}
+
+/**
+ * Gets the ingredient template directory.
+ *
+ * @param {string} ingredient Ingredient npm package name.
+ * @returns {string} Ingredient templates directory.
+ */
+function getIngredientTemplateDir(ingredient: string): string {
+  return join(process.cwd(), HYGEN_COOK_DIR, ingredient, '_templates');
 }
 
 /**
@@ -46,8 +57,9 @@ async function execInstruction({
   args = [],
 }: Instruction): Promise<void> {
   const cwd = basePath ? resolve(process.cwd(), basePath) : process.cwd();
-  await runHygen([`${ingredient}/${generator}`, action, ...prepareArgs(args)], {
+  await runHygen([generator, action, ...prepareArgs(args)], {
     cwd,
+    templates: getIngredientTemplateDir(ingredient),
   });
 }
 

--- a/src/main/hygen/run-hygen.ts
+++ b/src/main/hygen/run-hygen.ts
@@ -35,33 +35,19 @@ function createPrompter<Q, T>(): Prompter<Q, T> {
 }
 
 /**
- * Sets RunnerConfig.templates option, based on working directory.
- *
- * @param {RunnerConfig} config The runner configuration.
- * @returns {Pick<RunnerConfig, 'templates'>} The templates option on runner configuration.
- */
-function getHygenTemplatesOption(
-  config?: RunnerConfig,
-): Pick<RunnerConfig, 'templates'> {
-  if (config?.cwd === process.cwd()) return {};
-  return { templates: join(process.cwd(), '_templates') };
-}
-
-/**
  * Appends additional configs to the runner config.
  *
  * @param {RunnerConfig} config The runner configuration.
  * @returns {RunnerConfig}
  */
-function configureHygen(config?: RunnerConfig): RunnerConfig {
+function configureHygen(config: RunnerConfig): RunnerConfig {
   return {
-    cwd: process.cwd(),
+    cwd: join(process.cwd()),
     logger: new Logger(console.log.bind(console)),
     exec: execFn(config),
     // eslint-disable-next-line dot-notation
     debug: !!process.env['DEBUG'],
     createPrompter,
-    ...getHygenTemplatesOption(config),
     ...(config || {}),
   };
 }
@@ -75,7 +61,7 @@ function configureHygen(config?: RunnerConfig): RunnerConfig {
  */
 export async function runHygen(
   argv: string[],
-  config?: RunnerConfig,
+  config: RunnerConfig,
 ): Promise<ActionResult[]> {
   return engine(argv, await resolve(configureHygen(config)));
 }


### PR DESCRIPTION
Renamed `_templates` to `_hygencook`. New templates will be copied over to `_hygencook/${packageName}/_templates/${generatorName}`.