### PR TITLE
refactor: copy templates directory entirely instead of per generator

### DIFF
--- a/src/main/@types/copy-package-generator-args.type.ts
+++ b/src/main/@types/copy-package-generator-args.type.ts
@@ -1,9 +1,0 @@
-import { CookArgs } from './cook-args.type';
-import { NpmPackage } from './npm-package.type';
-
-export type CopyPackageGeneratorArgs = {
-  npmPackage: Pick<NpmPackage, 'name'>;
-  generator: string;
-  sourceTemplateDir: string;
-  hygenCookDir: string;
-} & Pick<CookArgs, 'shouldOverwriteTemplates'>;

--- a/src/main/@types/index.ts
+++ b/src/main/@types/index.ts
@@ -1,6 +1,5 @@
 export * from './arg.type';
 export * from './cook-args.type';
-export * from './copy-package-generator-args.type';
 export * from './instruction.type';
 export * from './npm-package.type';
 export * from './recipe.type';

--- a/src/main/hygen/run-hygen.ts
+++ b/src/main/hygen/run-hygen.ts
@@ -1,7 +1,6 @@
 import { engine, Logger, resolve } from 'hygen';
 import { RunnerConfig, Prompter, ActionResult } from 'hygen/src/types';
 import { command, ExecaChildProcess } from 'execa';
-import { join } from 'path';
 import enquirer from 'enquirer';
 
 /**
@@ -40,9 +39,9 @@ function createPrompter<Q, T>(): Prompter<Q, T> {
  * @param {RunnerConfig} config The runner configuration.
  * @returns {RunnerConfig}
  */
-function configureHygen(config: RunnerConfig): RunnerConfig {
+function configureHygen(config?: RunnerConfig): RunnerConfig {
   return {
-    cwd: join(process.cwd()),
+    cwd: process.cwd(),
     logger: new Logger(console.log.bind(console)),
     exec: execFn(config),
     // eslint-disable-next-line dot-notation
@@ -61,7 +60,7 @@ function configureHygen(config: RunnerConfig): RunnerConfig {
  */
 export async function runHygen(
   argv: string[],
-  config: RunnerConfig,
+  config?: RunnerConfig,
 ): Promise<ActionResult[]> {
   return engine(argv, await resolve(configureHygen(config)));
 }


### PR DESCRIPTION
There's no reason to copy generator by generator. We can copy the whole templates directory of the npm package directly. Makes the execution a bit faster.

The overwrite will work a bit differently, but I don't think that it matters.

And some leftovers from my previous PR.