### PR TITLE
fix: adds a package stub to the _hygencook dir to better handle ts files

### DIFF
--- a/src/main/add-ingredients.ts
+++ b/src/main/add-ingredients.ts
@@ -1,6 +1,7 @@
 import { mkdir } from 'async-fs-wrapper';
 import { green, yellow } from 'chalk';
 import execa from 'execa';
+import { writeFile } from 'fs/promises';
 import fs from 'fs-extra';
 import ora from 'ora';
 import { join, dirname } from 'path';
@@ -58,6 +59,12 @@ async function createHygenCookDir(): Promise<string> {
     await mkdir(hygenCookDirPath, {
       recursive: true,
     });
+    await writeFile(
+      join(hygenCookDirPath, 'package.json'),
+      JSON.stringify({
+        type: 'commonjs',
+      }),
+    );
   } catch (err) {
     // no problem if directory exists
   }

--- a/src/test/ingredients.unit.test.ts
+++ b/src/test/ingredients.unit.test.ts
@@ -1,3 +1,4 @@
+import { readFile } from 'async-fs-wrapper';
 import test from 'ava';
 import execa from 'execa';
 import { readdir, writeFile } from 'fs/promises';
@@ -71,6 +72,46 @@ test.serial('imports ingredients from npm modules', async (t) => {
     'styles',
   ]);
 });
+
+test.serial(
+  "adds a pseudo package json so that hygen doesn't throw an error reading ts prompt files in es modules",
+  async (t) => {
+    const recipe = {
+      name: 'testing',
+      ingredients: ['hygen-emiketic-react'],
+      instructions: [
+        {
+          ingredient: 'hygen-emiketic-react',
+          generator: 'react-native-component',
+          action: 'new',
+          args: [
+            {
+              option: 'name',
+              value: 'testing',
+            },
+            {
+              option: 'feature',
+              value: 'test-feature',
+            },
+          ],
+        },
+      ],
+    };
+    const yamlRecipe = dump(recipe);
+    await writeFile(resolve(execOpts.cwd, 'recipe.yml'), yamlRecipe);
+    await cook({
+      recipePath: resolve(execOpts.cwd, 'recipe.yml'),
+      shouldOverwriteTemplates: true,
+    });
+    const pkg = await readFile(
+      resolve(execOpts.cwd, '_hygencook/package.json'),
+      { encoding: 'utf8' },
+    );
+    t.deepEqual(JSON.parse(pkg), {
+      type: 'commonjs',
+    });
+  },
+);
 
 test.serial('imports ingredients from git repos', async (t) => {
   const recipe = {


### PR DESCRIPTION
Hygen can parse a .ts prompt file in a template using ts-node/register, which is cool, but if you're running templates in a directory where your package json has type: module that causes
ts-node/register to transpile to imports/exports instead of the commonjs format hygen needs. This
change drops a package.json stub into the _hygencook dir containing only type: "commonjs", which is enough to convince ts-node/register to transpile any .ts files to the correct syntax for hygen to be able to load.